### PR TITLE
Fix _normalize argument issue

### DIFF
--- a/bleu_ignoring.py
+++ b/bleu_ignoring.py
@@ -16,11 +16,39 @@
 
 import math
 import sys
-from fractions import Fraction
+from fractions import Fraction as _Fraction
 import warnings
 from collections import Counter
 
 from nltk.util import ngrams
+
+
+class Fraction(_Fraction):
+    """Fraction with _normalize=False support for 3.12"""
+
+    def __new__(cls, numerator=0, denominator=None, _normalize=False):
+        if sys.version_info >= (3, 12):
+            self = super().__new__(cls, numerator, denominator)
+        else:
+            self = super().__new__(cls, numerator, denominator, _normalize=_normalize)
+        self._normalize = _normalize
+        self._original_numerator = numerator
+        self._original_denominator = denominator
+        return self
+
+    @property
+    def numerator(self):
+        if not self._normalize:
+            return self._original_numerator
+        return super().numerator
+
+    @property
+    def denominator(self):
+        if not self._normalize:
+            return self._original_denominator
+        return super().denominator
+
+
 
 
 def sentence_bleu(


### PR DESCRIPTION
Hello @AryazE ,
I open this PR to make the crystalbleu package compatible with Python 3.12+ versions.

When using the `corpus_bleu` function with these versions, it returns the following exception:
`TypeError: Fraction.__new__() got an unexpected keyword argument '_normalize'`

The original NLTK implementation fixes the problem updating the `Fraction` class as follows:
https://www.nltk.org/_modules/nltk/translate/bleu_score.html

In this PR I mimic their modification. I've tested it locally and it finally fixed the problem. 
However it would be nice to run some tests before releasing the package (if available).

This should also fix #2 